### PR TITLE
Fix the link to SilverCare repo after pressing github icon

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,7 +8,7 @@ header_pages:
 
 markdown: kramdown
 
-repository: "se-edu/addressbook-level3"
+repository: "AY2425S2-CS2103T-T12-4/tp"
 github_icon: "images/github-icon.png"
 
 plugins:


### PR DESCRIPTION
fixes #225 